### PR TITLE
🧼 [printers] add a third version of the Gemini 10x manual

### DIFF
--- a/Computer/Printer/README.md
+++ b/Computer/Printer/README.md
@@ -1,7 +1,6 @@
 # Computer/Printer manuals
 
-Thanks to [SuperUser](https://superuser.com/q/622950/358509) for helping to
-clean up PDFs with ImageMagick.
+## Files
 
 ```shell
  15M Aug 23  2024 Cardprint_Commodore_printer_interface.pdf
@@ -9,4 +8,41 @@ clean up PDFs with ImageMagick.
 194M May 13 16:52 LaserJet_III_Technical_Reference_Manual.pdf
 395M May 13 09:09 Star_Gemini_10x15x_User_Manual_brighter.pdf
  72M May 13 09:09 Star_Gemini_10x15x_User_Manual_raw.pdf
+ 53M Aug 28 16:24 Star_Gemini_10x15x_User_Manual_cocoarchive.pdf
 ```
+
+### Star Gemini 10x
+
+The Star Gemini 10x was my very first printer many many moons ago.
+All of these years later I still had the printed, spiral-bound user manual.
+So I searched to see if anyone had scanned it in, and much to my surprise,
+folks had already scanned it in, but their version was different and less
+complete than mine.
+
+Obviously I needed to scan mine in.  So I gathered my courage and pried
+the pages from the binding.  I ran it through my trusty Brother page feed
+scanner and this produced the [raw version](Star_Gemini_10x15x_User_Manual_raw.pdf)
+of the manual.  I sent it off to a few places and the maintainer of the
+[TRS-80 Color Computer Archive](https://colorcomputerarchive.com/) pointed
+out that it didn't look very good.
+
+The criticism that it didn't look good was totally fair, so I looked for a
+solution and eventually found an answer on
+[SuperUser](https://superuser.com/q/622950/358509) that helped me clean up
+the raw version with ImageMagick.  This led the
+[brighter version](Star_Gemini_10x15x_User_Manual_brighter.pdf).
+
+The brighter version was an improvement, but not a complete solution.
+For one thing it ballooned the file size by 5x for unclear reasons.
+And it also didn't totally get rid of the page discoloration that was
+most distracting.  But it was the best that I could figure out how to
+do, so I sent it back to the fine maintainer of the Color Computer Archive.
+
+Months pass.  Retrocomputing people are either not in a hurry or they are
+very busy, but that beside the point.  After I had stopped looking for any
+reply, I heard back.  And they had cleaned up the PDF by hand and produced
+[the most glorious version](https://colorcomputerarchive.com/repo/Documents/Manuals/Hardware/Gemini%2010X-15X%20User's%20Manual%20(Star%20Micronics%29.pdf)
+yet.  I'm calling this the
+[cocoarchive version](Star_Gemini_10x15x_User_Manual_cocoarchive.pdf) and
+there is no doubt that it is the best: easiest to read and the smallest
+file size yet.  Bravo.

--- a/Computer/Printer/Star_Gemini_10x15x_User_Manual_cocoarchive.pdf
+++ b/Computer/Printer/Star_Gemini_10x15x_User_Manual_cocoarchive.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ece2e564bbd5b187535d85dfd5dad50d8c913d07fd31cc1a3f08e5905eefd20
+size 55605394


### PR DESCRIPTION
Kudos to the https://colorcomputerarchive.com/ for being such a fine resource for the whole retrocomputing community and for hand cleaning this PDF.  I wish I had those skills and patience.